### PR TITLE
Added the physical allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/not-matthias/kernel-alloc-rs"
 license-file = "LICENSE"
 
 [dependencies]
+winapi = { git = "https://github.com/Trantect/winapi-rs.git", branch = "feature/km", default-features = false, features = ["wdm", "ntstatus"] }
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Rust has many useful abstractions and utils that require heap allocations. `String`, `Vec` and `Box` are some of them. To be able to use them, we need to allocate memory at runtime, which requires a custom allocator. 
 
-If you want to find out more about it, please refer to the [alloc::GlobalAllocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) and the [Rust book](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/global-allocators.html). 
+If you want to find out more about it, please refer to the [alloc::GlobalAllocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) or [alloc::Allocator](https://doc.rust-lang.org/std/alloc/trait.Allocator.html) and the Rust book for [global_allocator](https://doc.rust-lang.org/1.26.2/unstable-book/language-features/global-allocator.html) or [allocator_api](https://doc.rust-lang.org/1.26.2/unstable-book/library-features/allocator-api.html). 
 
 ## Example
 
@@ -19,4 +19,10 @@ use kernel_alloc::KernelAlloc;
 
 #[global_allocator]
 static GLOBAL: KernelAlloc = KernelAlloc;
+```
+
+Add the following to your code to define new physical allocator: 
+
+```rust
+use kernel_alloc::PhysicalAllocator;
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! `String`, `Vec` and `Box` are some of them. To be able to use them, we need
 //! to allocate memory at runtime, which requires a custom allocator.
 //!
-//! If you want to find out more about it, please refer to the [alloc::GlobalAllocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) and the [Rust book](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/global-allocators.html).
+//! If you want to find out more about it, please refer to the [alloc::GlobalAllocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) or [alloc::Allocator](https://doc.rust-lang.org/std/alloc/trait.Allocator.html) and the Rust book for [global_allocator](https://doc.rust-lang.org/1.26.2/unstable-book/language-features/global-allocator.html) or [allocator_api](https://doc.rust-lang.org/1.26.2/unstable-book/library-features/allocator-api.html).
 //!
 //! ## Example
 //!
@@ -14,15 +14,29 @@
 //! #[global_allocator]
 //! static GLOBAL: KernelAlloc = KernelAlloc;
 //! ```
+//!
+//! ## Example
+//!
+//! Add the following to your code to define new physical allocator:
+//!
+//! ```rust
+//! use kernel_alloc::PhysicalAllocator;
+//! ```
 
 #![no_std]
 #![feature(alloc_error_handler)]
+#![feature(allocator_api)]
 
 extern crate alloc;
 
-use crate::nt::{ExFreePool, PoolType};
+use crate::nt::{ExFreePool, PoolType, MEMORY_CACHING_TYPE::MmCached};
 use alloc::alloc::handle_alloc_error;
-use core::alloc::{GlobalAlloc, Layout};
+use core::{
+    alloc::{AllocError, Allocator, GlobalAlloc, Layout},
+    ptr::NonNull,
+};
+use nt::{MmAllocateContiguousMemorySpecifyCacheNode, MmFreeContiguousMemory, MM_ANY_NODE_OK};
+use winapi::shared::ntdef::PHYSICAL_ADDRESS;
 
 #[doc(hidden)] pub mod nt;
 
@@ -31,6 +45,9 @@ const POOL_TAG: u32 = u32::from_ne_bytes(*b"tsuR");
 
 /// The global kernel allocator structure.
 pub struct KernelAlloc;
+
+/// The physical kernel allocator structure.
+pub struct PhysicalAllocator;
 
 unsafe impl GlobalAlloc for KernelAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -47,6 +64,37 @@ unsafe impl GlobalAlloc for KernelAlloc {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) { ExFreePool(ptr as _); }
+}
+
+unsafe impl Allocator for PhysicalAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let mut boundary: PHYSICAL_ADDRESS = unsafe { core::mem::zeroed() };
+        let mut lowest: PHYSICAL_ADDRESS = unsafe { core::mem::zeroed() };
+        let mut highest: PHYSICAL_ADDRESS = unsafe { core::mem::zeroed() };
+
+        unsafe { *(boundary.QuadPart_mut()) = 0 };
+        unsafe { *(lowest.QuadPart_mut()) = 0 };
+        unsafe { *(highest.QuadPart_mut()) = -1 };
+
+        let memory = unsafe {
+            MmAllocateContiguousMemorySpecifyCacheNode(
+                layout.size(),
+                lowest,
+                highest,
+                boundary,
+                MmCached,
+                MM_ANY_NODE_OK,
+            )
+        } as *mut u8;
+        if memory.is_null() {
+            Err(AllocError)
+        } else {
+            let slice = unsafe { core::slice::from_raw_parts_mut(memory, layout.size()) };
+            Ok(unsafe { NonNull::new_unchecked(slice) })
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) { MmFreeContiguousMemory(ptr.cast().as_ptr()); }
 }
 
 #[alloc_error_handler]

--- a/src/nt.rs
+++ b/src/nt.rs
@@ -1,3 +1,8 @@
+use winapi::shared::{
+    basetsd::SIZE_T,
+    ntdef::{PHYSICAL_ADDRESS, PVOID},
+};
+
 #[repr(C)]
 pub enum PoolType {
     NonPagedPool,
@@ -9,4 +14,25 @@ extern "system" {
     pub fn ExAllocatePool(pool_type: PoolType, number_of_bytes: usize) -> *mut u64;
     pub fn ExAllocatePoolWithTag(pool_type: PoolType, number_of_bytes: usize, tag: u32) -> *mut u64;
     pub fn ExFreePool(pool: u64);
+    pub fn MmAllocateContiguousMemorySpecifyCacheNode(
+        NumberOfBytes: SIZE_T, LowestAcceptableAddress: PHYSICAL_ADDRESS, HighestAcceptableAddress: PHYSICAL_ADDRESS,
+        BoundaryAddressMultiple: PHYSICAL_ADDRESS, CacheType: MEMORY_CACHING_TYPE, PreferredNode: NODE_REQUIREMENT,
+    ) -> PVOID;
+    pub fn MmFreeContiguousMemory(BaseAddress: PVOID);
+}
+
+pub const MM_ANY_NODE_OK: u32 = 0x80000000;
+#[allow(non_camel_case_types)]
+pub type NODE_REQUIREMENT = u32;
+
+#[repr(C)]
+pub enum MEMORY_CACHING_TYPE {
+    MmNonCached = 0,
+    MmCached = 1,
+    MmWriteCombined = 2,
+    MmHardwareCoherentCached,
+    MmNonCachedUnordered,
+    MmUSWCCached,
+    MmMaximumCacheType,
+    MmNotMapped = -1,
 }


### PR DESCRIPTION
In the process of making an Intel VT-x hypervisor, I noticed that your `kernel-alloc-rs` crate is missing a physical allocator. However, I noticed that you had already made a physical allocator when you made an AMD Secure Virtual Machine (SVM) hypervisor. This PR will add the physical allocator you made to your own `kernel-alloc-rs` crate. Hopefully, I did it correctly, if not then feel free to edit. Thanks.

## Credits / References

Full credits to you :)

* https://not-matthias.github.io/posts/rust-kernel-adventures/
* https://github.com/not-matthias/amd_hypervisor/blob/main/hypervisor/src/utils/alloc.rs