### PR TITLE
Resolved `ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY` error using `ExAllocatePool` with `NonPagedPoolExecute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ use kernel_alloc::PhysicalAllocator;
 #[global_allocator]
 static GLOBAL: PhysicalAllocator = PhysicalAllocator;
 ```
+
+## Credits / References
+
+- https://www.vergiliusproject.com/
+- @not-matthias, @jessiep_, @memN0ps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,16 @@
 
 extern crate alloc;
 
-use crate::nt::{ExFreePool, PoolType, MEMORY_CACHING_TYPE::MmCached};
+use crate::nt::{ExFreePool, MEMORY_CACHING_TYPE::MmCached};
 use alloc::alloc::handle_alloc_error;
 use core::{
     alloc::{AllocError, Allocator, GlobalAlloc, Layout},
     ptr::NonNull,
 };
-use nt::{MmAllocateContiguousMemorySpecifyCacheNode, MmFreeContiguousMemory, MM_ANY_NODE_OK};
+use nt::{
+    MmAllocateContiguousMemorySpecifyCacheNode, MmFreeContiguousMemory, NonPagedPool,
+    MM_ANY_NODE_OK,
+};
 use winapi::shared::ntdef::PHYSICAL_ADDRESS;
 
 #[doc(hidden)] pub mod nt;
@@ -55,10 +58,10 @@ pub struct PhysicalAllocator;
 unsafe impl GlobalAlloc for KernelAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         #[cfg(feature = "pool-tag")]
-        let pool = nt::ExAllocatePoolWithTag(PoolType::NonPagedPool, layout.size(), POOL_TAG);
+        let pool = nt::ExAllocatePoolWithTag(NonPagedPool, layout.size(), POOL_TAG);
 
         #[cfg(not(feature = "pool-tag"))]
-        let pool = nt::ExAllocatePool(PoolType::NonPagedPool, layout.size());
+        let pool = nt::ExAllocatePool(NonPagedPool, layout.size());
         if pool.is_null() {
             handle_alloc_error(layout);
         }

--- a/src/nt.rs
+++ b/src/nt.rs
@@ -1,16 +1,40 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
 use winapi::shared::ntdef::PHYSICAL_ADDRESS;
 
-#[repr(C)]
-pub enum PoolType {
-    NonPagedPool,
-    NonPagedPoolExecute,
-}
+pub type POOL_TYPE = i32;
+
+pub const PagedPool: POOL_TYPE = 1;
+pub const NonPagedPool: POOL_TYPE = 0;
+pub const NonPagedPoolExecute: POOL_TYPE = 0;
+pub const NonPagedPoolMustSucceed: POOL_TYPE = 2;
+pub const DontUseThisType: POOL_TYPE = 3;
+pub const NonPagedPoolCacheAligned: POOL_TYPE = 4;
+pub const PagedPoolCacheAligned: POOL_TYPE = 5;
+pub const NonPagedPoolCacheAlignedMustS: POOL_TYPE = 6;
+pub const MaxPoolType: POOL_TYPE = 7;
+pub const NonPagedPoolBase: POOL_TYPE = 0;
+pub const NonPagedPoolBaseMustSucceed: POOL_TYPE = 2;
+pub const NonPagedPoolBaseCacheAligned: POOL_TYPE = 4;
+pub const NonPagedPoolBaseCacheAlignedMustS: POOL_TYPE = 6;
+pub const NonPagedPoolSession: POOL_TYPE = 32;
+pub const PagedPoolSession: POOL_TYPE = 33;
+pub const NonPagedPoolMustSucceedSession: POOL_TYPE = 34;
+pub const DontUseThisTypeSession: POOL_TYPE = 35;
+pub const NonPagedPoolCacheAlignedSession: POOL_TYPE = 36;
+pub const PagedPoolCacheAlignedSession: POOL_TYPE = 37;
+pub const NonPagedPoolCacheAlignedMustSSession: POOL_TYPE = 38;
+pub const NonPagedPoolNx: POOL_TYPE = 512;
+pub const NonPagedPoolNxCacheAligned: POOL_TYPE = 516;
+pub const NonPagedPoolSessionNx: POOL_TYPE = 544;
 
 #[link(name = "ntoskrnl")]
 extern "system" {
-    pub fn ExAllocatePool(pool_type: PoolType, number_of_bytes: usize) -> *mut u64;
-    pub fn ExAllocatePoolWithTag(pool_type: PoolType, number_of_bytes: usize, tag: u32)
-        -> *mut u64;
+    pub fn ExAllocatePool(pool_type: POOL_TYPE, number_of_bytes: usize) -> *mut u64;
+    pub fn ExAllocatePoolWithTag(
+        pool_type: POOL_TYPE, number_of_bytes: usize, tag: u32,
+    ) -> *mut u64;
     pub fn ExFreePool(pool: u64);
     pub fn MmAllocateContiguousMemorySpecifyCacheNode(
         NumberOfBytes: usize, LowestAcceptableAddress: PHYSICAL_ADDRESS,
@@ -21,17 +45,16 @@ extern "system" {
 }
 
 pub const MM_ANY_NODE_OK: u32 = 0x80000000;
-#[allow(non_camel_case_types)]
 pub type NODE_REQUIREMENT = u32;
 
-#[repr(C)]
+#[repr(i32)]
 pub enum MEMORY_CACHING_TYPE {
     MmNonCached = 0,
     MmCached = 1,
     MmWriteCombined = 2,
-    MmHardwareCoherentCached,
-    MmNonCachedUnordered,
-    MmUSWCCached,
-    MmMaximumCacheType,
+    MmHardwareCoherentCached = 3,
+    MmNonCachedUnordered = 4,
+    MmUSWCCached = 5,
+    MmMaximumCacheType = 6,
     MmNotMapped = -1,
 }


### PR DESCRIPTION
This pull request addresses an issue related to the `NonPagedPoolExecute` inside the `POOL_TYPE` enum when using `ExAllocatePool`. It includes the following changes:

- Attempting to use `NonPagedPoolExecute` gave the error `ATTEMPTED_EXECUTE_OF_NOEXECUTE_MEMORY` with `ExAllocatePool`.
- You will get the error message `discriminant value '0' assigned more than once` if you use an enum for `POOL_TYPE`, so it's converted to `pub const` instead.
