### PR TITLE
Enhance Allocator Documentation, Examples, and Trait Implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-alloc"
-version = "0.2.2"
+version = "0.2.3"
 description = "Minimalistic Windows Kernel Allocator"
 authors = ["not-matthias <26800596+not-matthias@users.noreply.github.com>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@
 
 # kernel-alloc-rs
 
+A custom memory allocator tailored for the Windows kernel space.
+
 ## Why?
 
-Rust has many useful abstractions and utils that require heap allocations. `String`, `Vec` and `Box` are some of them. To be able to use them, we need to allocate memory at runtime, which requires a custom allocator. 
+Rust has many useful abstractions and utils that require heap allocations, such as `String`, `Vec`, and `Box`. To be able to use them in the Windows kernel space, we need to allocate memory at runtime, which requires a custom allocator. This crate provides such allocators tailored for the Windows kernel.
 
-If you want to find out more about it, please refer to the [alloc::GlobalAllocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) or [alloc::Allocator](https://doc.rust-lang.org/std/alloc/trait.Allocator.html) and the Rust book for [global_allocator](https://doc.rust-lang.org/1.26.2/unstable-book/language-features/global-allocator.html) or [allocator_api](https://doc.rust-lang.org/1.26.2/unstable-book/library-features/allocator-api.html). 
+For more information on custom allocators in Rust, refer to the [alloc::GlobalAllocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) and [alloc::Allocator](https://doc.rust-lang.org/std/alloc/trait.Allocator.html) documentation. Additionally, the Rust book provides details on [global_allocator](https://doc.rust-lang.org/1.26.2/unstable-book/language-features/global-allocator.html) and [allocator_api](https://doc.rust-lang.org/1.26.2/unstable-book/library-features/allocator-api.html).
 
 ## Example
 
-Add the following to your code to define new global allocator: 
+To use `KernelAlloc` or `PhysicalAllocator` as your global allocator, add the appropriate code to your kernel module:
+
+For `KernelAlloc`:
 
 ```rust
 use kernel_alloc::KernelAlloc;
@@ -21,7 +25,7 @@ use kernel_alloc::KernelAlloc;
 static GLOBAL: KernelAlloc = KernelAlloc;
 ```
 
-Add the following to your code to define new physical allocator: 
+For `PhysicalAllocator`:
 
 ```rust
 use kernel_alloc::PhysicalAllocator;
@@ -30,7 +34,54 @@ use kernel_alloc::PhysicalAllocator;
 static GLOBAL: PhysicalAllocator = PhysicalAllocator;
 ```
 
+## Using with `Box`
+
+Once you've set up `KernelAlloc` or `PhysicalAllocator` as your global allocator, you can use `Box` and other heap-allocated types just like you would in a standard Rust environment.
+
+Here's an example demonstrating how to use both `KernelAlloc` and `PhysicalAllocator` with `Box` to allocate memory for different structs in the Windows kernel:
+
+```rust
+use kernel_alloc::{KernelAlloc, PhysicalAllocator};
+use core::mem;
+
+pub const PAGE_SIZE: usize = 0x1000;
+pub const KERNEL_STACK_SIZE: usize = 0x6000;
+pub const STACK_CONTENTS_SIZE: usize = KERNEL_STACK_SIZE - (mem::size_of::<*mut u64>() * 2);
+
+#[repr(C, align(4096))]
+pub struct Vmxon {
+    pub revision_id: u32,
+    pub data: [u8; PAGE_SIZE - 4],
+}
+
+#[repr(C, align(4096))]
+pub struct HostStackLayout {
+    pub stack_contents: [u8; STACK_CONTENTS_SIZE],
+    pub padding_1: u64,
+    pub reserved_1: u64,
+}
+
+pub struct Vmx {
+    pub vmxon_region: Box<Vmxon, PhysicalAllocator>,
+    pub host_rsp: Box<HostStackLayout, KernelAlloc>,
+}
+
+impl Vmx {
+    pub fn new() -> Result<Self, AllocError> {
+        let vmxon_region = unsafe { Box::try_new_zeroed_in(PhysicalAllocator)?.assume_init() };
+        let host_rsp = unsafe { Box::try_new_zeroed_in(KernelAlloc)?.assume_init() };
+
+        Ok(Self {
+            vmxon_region: vmxon_region,
+            host_rsp: host_rsp,
+        })
+    }
+}
+```
+
 ## Credits / References
 
-- https://www.vergiliusproject.com/
-- @not-matthias, @jessiep_, @memN0ps
+- [Vergilius Project](https://www.vergiliusproject.com/)
+- [@not-matthias](https://github.com/not-matthias/)
+- @jessiep_
+- [@memN0ps](https://github.com/memN0ps/)


### PR DESCRIPTION
Hey @not-matthias,

This PR introduces several key improvements to the `kernel-alloc-rs` crate:

1. **Documentation Enhancement:** Updated the `README.md` to explain the crate's purpose more precisely, emphasizing its utility in the Windows kernel space.
2. **Examples Update:** Added comprehensive examples in the `README.md` to demonstrate using both `KernelAlloc` and `PhysicalAllocator` with `Box` in the Windows kernel context.
3. **Trait Implementation:** Modified `lib.rs` to add the `Allocator` trait for `KernelAlloc`, ensuring compatibility with Rust's standard allocation API.
4. **Code Refinement:** Made minor adjustments to the codebase for clarity, maintainability, and to align with best practices.

These changes aim to enhance the user experience by better understanding the crate's capabilities and ensuring seamless integration with Rust's standard allocation mechanisms.
