### PR TITLE
Added Clone derive to allocators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,11 @@ use winapi::shared::ntdef::PHYSICAL_ADDRESS;
 const POOL_TAG: u32 = u32::from_ne_bytes(*b"tsuR");
 
 /// The global kernel allocator structure.
+#[derive(Clone)]
 pub struct KernelAlloc;
 
 /// The physical kernel allocator structure.
+#[derive(Clone)]
 pub struct PhysicalAllocator;
 
 unsafe impl GlobalAlloc for KernelAlloc {


### PR DESCRIPTION
`Clone` can be needed for specific types, such as `Rc` or `Arc`. You allocators are ZST, thus I think it is fine to derive Clone for them.